### PR TITLE
Updated solr_wrapper gem to v2.1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,7 +244,7 @@ GEM
       rsolr
       sanitize
       solrizer (>= 3.1.0, < 4)
-    solr_wrapper (2.0.0)
+    solr_wrapper (2.1.0)
       faraday
       retriable
       ruby-progressbar


### PR DESCRIPTION
Updated solr_wrapper gem to v2.1.0 to fix solr-7.6.0.zip.sha1
(SolrWrapper::SolrWrapperError) when constructing container